### PR TITLE
Shortcuts in inputfield

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -40,6 +40,13 @@
 	</header>
 
 	<div class="content">
+		<section>
+			<h2 id="form"><a href="#">Sample with inputfields</a></h2>
+			<form action="">
+				<input type="text">
+				<textarea name="" id="" cols="30" rows="10"></textarea>
+			</form>
+		</section>
 		<section class="intro">
 			<h2 id="overview"><a href="#">Version 1.1</a></h2>
 			<div class="text">
@@ -549,6 +556,11 @@ jPM.<span class="function">trigger</span>(true);</pre>
 
 	-->
 
-	<script src="js/script.min.js"></script>
+	<script src="js/lib/modernizr-2.6.1.min.js"></script>
+	<script src="js/lib/respond-1.1.0.min.js"></script>
+	<script src="../jPanelMenu-1.1.0.js"></script>
+	<script src="js/lib/highlight.min.js"></script>
+	<script src="js/lib/plugins.js"></script>
+	<script src="js/script.js"></script>
 </body>
 </html>

--- a/jPanelMenu-1.1.0.js
+++ b/jPanelMenu-1.1.0.js
@@ -443,7 +443,18 @@
 			},
 
 			initiateKeyboardListeners: function() {
+				var preventKeyListeners = ['input', 'textarea'];
 				$(document).on('keydown',function(e){
+					var $target = $(e.target),
+					prevent = false;
+					$.each(preventKeyListeners, function(){
+						if ($target.is(this.toString())) { // no shurtcuts in form fields
+							prevent = true;
+						}
+					});
+					if (prevent) {
+						return true;
+					}
 					for ( mapping in jP.options.keyboardShortcuts ) {
 						if ( e.which == jP.options.keyboardShortcuts[mapping].code )
 						{


### PR DESCRIPTION
Solves issue #9.
Prevents action of shortcuts if the target of the keydown is a input or textarea.
