### PR TITLE
click events on the document are squashed with return false

### DIFF
--- a/jquery.jpanelmenu.js
+++ b/jquery.jpanelmenu.js
@@ -427,7 +427,7 @@
 			},
 
 			initiateClickListeners: function() {
-				$(document).on('click',jP.options.trigger,function(){ jP.triggerMenu(jP.options.animated); return false; });
+				$(document).on('click',jP.options.trigger,function(e){ jP.triggerMenu(jP.options.animated); e.preventDefault(); });
 			},
 
 			destroyClickListeners: function() {


### PR DESCRIPTION
swapped a 'return false' with a e.preventDefault() to allow other click event handlers on the document to proceed without a hitch.
