### PR TITLE
Prevent triggering of link that slides into spot where menu trigger is located when closing menu

### DIFF
--- a/jquery.jpanelmenu.js
+++ b/jquery.jpanelmenu.js
@@ -442,6 +442,7 @@
 				});
 				
 				$(document).on('touchend',jP.panel,function(e){
+          e.preventDefault();
 					if ( jP.menuIsOpen() ) jP.closeMenu(jP.options.animated);
 				});
 			},


### PR DESCRIPTION
In a design I'm working on, when the menu trigger is tapped to close the menu, the tap also triggers the link that slides into the spot the menu trigger occupied. You can prevent this sort of thing from happening in mobile browsers by adding a preventDefault to the event, which is what I did. I'm guessing that there are other cases that I did not personally encounter where your library would benefit from this addition.

This happens in Chrome for Android and Safari on iOS. Probably other mobile browsers, too.
