### PR TITLE
Makes jPanelMenu work better with Ember.js framework

### DIFF
--- a/jquery.jpanelmenu.js
+++ b/jquery.jpanelmenu.js
@@ -14,6 +14,7 @@
 				menu: '#menu',
 				trigger: '.menu-trigger',
 				excludedPanelContent: 'style, script',
+        moveMenu: false,
 
 				direction: 'left',
 				openPosition: '250px',
@@ -485,7 +486,8 @@
 			setupMarkup: function() {
 				$('html').addClass('jPanelMenu');
 				$('body > *').not(jP.menu + ', ' + jP.options.excludedPanelContent).wrapAll('<div class="' + jP.panel.replace('.','') + '"/>');
-				$(jP.options.menu).clone().attr('id', jP.menu.replace('#','')).insertAfter('body > ' + jP.panel);
+        var menu = jP.options.moveMenu ? $(jP.options.menu) : $(jP.options.menu).clone();
+				menu.attr('id', jP.menu.replace('#','')).insertAfter('body > ' + jP.panel);
 			},
 
 			resetMarkup: function() {


### PR DESCRIPTION
- Changes allowedUnits loop in setPosition method to a traditional for loop to avoid iterating over prototype properties if the Array class has been decorated by another framework or plugin (such as Ember.js).
- Adds a new option called moveMenu that defaults to false to preserve existing behavior, but when set to true will skip the clone of the menu elements and relocate them instead. This allows Ember to inject nodes into the DOM without getting confused by duplicate multiple copies of elements.
