### PR TITLE
Fixed non existing unit with key "firstObject".

### DIFF
--- a/jquery.jpanelmenu.js
+++ b/jquery.jpanelmenu.js
@@ -98,7 +98,7 @@
 					allowedUnits = ['%','px','em']
 				;
 
-				for ( unitID in allowedUnits ) {
+				for (var unitID = 0; unitID < allowedUnits.length; unitID++) {
 					var unit = allowedUnits[unitID];
 					if ( jP.options.openPosition.toString().substr(-unit.length) == unit )
 					{


### PR DESCRIPTION
When I use jPanelMenu the following exception occurs.

![undefined unit](https://f.cloud.github.com/assets/504049/1939162/66334632-7f5c-11e3-9a94-4114a014073b.PNG)

Unfortunately I can't narrow this issue down. My best guess that it has something todo with Ember.js (a library that I use).

If we debug the exception you will see that there is another element in the array with the key "firstObject".

![undefined_firstobject](https://f.cloud.github.com/assets/504049/1939173/c09c0b18-7f5c-11e3-8ddc-649fdf646d69.png)

Fixing this is easy. Just switch to the normal for loop.
